### PR TITLE
refactor: unify usage of ruamel

### DIFF
--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -6,7 +6,7 @@ from enum import Enum
 from inspect import cleandoc
 from typing import Any, Dict, List, Literal, Optional, Union
 
-import yaml
+from ruamel.yaml import YAML
 from pydantic import BaseModel, Field, create_model, ConfigDict
 
 from conda.base.constants import KNOWN_SUBDIRS
@@ -1257,7 +1257,8 @@ class ConfigModel(BaseModel):
 if __name__ == "__main__":
     # This is used to generate the model dump for conda-smithy internal use
     # and for documentation purposes.
-
+    yaml = YAML()
+    yaml.indent(mapping=2, sequence=4, offset=2)
     model = ConfigModel()
 
     with CONDA_FORGE_YAML_SCHEMA_FILE.open(mode="w+") as f:
@@ -1266,4 +1267,4 @@ if __name__ == "__main__":
         f.write("\n")
 
     with CONDA_FORGE_YAML_DEFAULTS_FILE.open(mode="w+") as f:
-        f.write(yaml.dump(model.model_dump(), indent=2))
+        f.write(yaml.dump(model.model_dump()))

--- a/news/ruamel-refactor.rst
+++ b/news/ruamel-refactor.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Use ruamel library and remove usage of yaml almost everywhere - except at conda-smithy/variant_algebra.py
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import os
 from textwrap import dedent
 
 import pytest
-import yaml
+from ruamel.yaml import YAML
 
 from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
@@ -55,6 +55,8 @@ def recipe_dirname():
 
 @pytest.fixture(scope="function")
 def config_yaml(testing_workdir, recipe_dirname):
+    yaml = YAML()
+    yaml.default_flow_style = False
     config = {"python": ["2.7", "3.5"], "r_base": ["3.3.2", "3.4.2"]}
     os.makedirs(os.path.join(testing_workdir, recipe_dirname))
     with open(os.path.join(testing_workdir, "config.yaml"), "w") as f:
@@ -65,7 +67,7 @@ def config_yaml(testing_workdir, recipe_dirname):
         os.path.join(testing_workdir, recipe_dirname, "default_config.yaml"),
         "w",
     ) as f:
-        yaml.dump(config, f, default_flow_style=False)
+        yaml.dump(config, f)
         # need selectors, so write these more manually
         f.write(
             dedent(
@@ -94,18 +96,18 @@ def config_yaml(testing_workdir, recipe_dirname):
         os.path.join(testing_workdir, recipe_dirname, "short_config.yaml"), "w"
     ) as f:
         config = {"python": ["2.7"]}
-        yaml.dump(config, f, default_flow_style=False)
+        yaml.dump(config, f)
     with open(
         os.path.join(testing_workdir, recipe_dirname, "long_config.yaml"), "w"
     ) as f:
         config = {"python": ["2.7", "3.5", "3.6"]}
-        yaml.dump(config, f, default_flow_style=False)
+        yaml.dump(config, f)
     with open(os.path.join(testing_workdir, "conda-forge.yml"), "w") as f:
         config = {
             "upload_on_branch": "foo-branch",
             "recipe_dir": recipe_dirname,
         }
-        yaml.dump(config, f, default_flow_style=False)
+        yaml.dump(config, f)
     return testing_workdir
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,13 +4,15 @@ import os
 import subprocess
 from textwrap import dedent
 
-import yaml
+from ruamel.yaml import YAML
 import pytest
 import shutil
 
 from conda_smithy import cli
 
 _thisdir = os.path.abspath(os.path.dirname(__file__))
+
+yaml = YAML(typ='safe')
 
 InitArgs = collections.namedtuple(
     "ArgsObject",
@@ -79,7 +81,7 @@ def test_init_with_custom_config(py_recipe):
     init_obj(args)
     destination = os.path.join(recipe, "py-test-feedstock")
     assert os.path.isdir(destination)
-    data = yaml.safe_load(
+    data = yaml.load(
         open(os.path.join(destination, "conda-forge.yml"), "r").read()
     )
     assert data.get("bot") != None
@@ -125,7 +127,7 @@ def test_init_multiple_output_matrix(testing_workdir):
     )
     assert os.path.isfile(linux_libpng16)
     with open(linux_libpng16) as f:
-        config = yaml.safe_load(f)
+        config = yaml.load(f)
     assert config["libpng"] == ["1.6"]
     assert config["libpq"] == ["9.5"]
     # this is a zipped key, but it's not used, so it shouldn't show up
@@ -240,7 +242,7 @@ def test_init_cuda_docker_images(testing_workdir):
         )
         assert os.path.isfile(fn)
         with open(fn) as fh:
-            config = yaml.safe_load(fh)
+            config = yaml.load(fh)
         assert config["cuda_compiler"] == ["nvcc"]
         assert config["cuda_compiler_version"] == [f"{v}"]
         if v is None:
@@ -291,7 +293,7 @@ def test_init_multiple_docker_images(testing_workdir):
     fn = os.path.join(matrix_dir, "linux_64_.yaml")
     assert os.path.isfile(fn)
     with open(fn) as fh:
-        config = yaml.safe_load(fh)
+        config = yaml.load(fh)
     assert config["docker_image"] == ["pickme_a"]
     assert config["cdt_name"] == ["pickme_1"]
 
@@ -368,5 +370,5 @@ def test_render_variant_mismatches(testing_workdir):
             continue
         cfg = os.path.join(matrix_dir, _cfg)
         with open(cfg, "r") as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f)
         assert data["a"] == data["b"]

--- a/tests/test_condaforge_config_schema.py
+++ b/tests/test_condaforge_config_schema.py
@@ -1,6 +1,5 @@
 import pytest
 from pydantic import ValidationError
-import yaml
 from conda_smithy.schema import ConfigModel
 
 

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -7,10 +7,11 @@ import textwrap
 from pathlib import Path
 
 import pytest
-import yaml
+from ruamel.yaml import YAML
 
 from conda_smithy import configure_feedstock
 
+yaml=YAML(typ='safe')
 
 def test_noarch_skips_appveyor(noarch_recipe, jinja_env):
     noarch_recipe.config["provider"]["win"] = "appveyor"
@@ -293,7 +294,7 @@ def test_upload_on_branch_azure(upload_on_branch_recipe, jinja_env):
             "azure-pipelines-osx.yml",
         )
     ) as fp:
-        content_osx = yaml.safe_load(fp)
+        content_osx = yaml.load(fp)
     assert (
         'UPLOAD_ON_BRANCH="foo-branch"'
         in content_osx["jobs"][0]["steps"][0]["script"]
@@ -310,7 +311,7 @@ def test_upload_on_branch_azure(upload_on_branch_recipe, jinja_env):
             "azure-pipelines-win.yml",
         )
     ) as fp:
-        content_win = yaml.safe_load(fp)
+        content_win = yaml.load(fp)
     win_build_step = next(
         step
         for step in content_win["jobs"][0]["steps"]
@@ -334,7 +335,7 @@ def test_upload_on_branch_azure(upload_on_branch_recipe, jinja_env):
             "azure-pipelines-linux.yml",
         )
     ) as fp:
-        content_lin = yaml.safe_load(fp)
+        content_lin = yaml.load(fp)
     assert (
         'UPLOAD_ON_BRANCH="foo-branch"'
         in content_lin["jobs"][0]["steps"][1]["script"]
@@ -360,7 +361,7 @@ def test_upload_on_branch_appveyor(upload_on_branch_recipe, jinja_env):
     with open(
         os.path.join(upload_on_branch_recipe.recipe, ".appveyor.yml")
     ) as fp:
-        content = yaml.safe_load(fp)
+        content = yaml.load(fp)
     assert "%APPVEYOR_REPO_BRANCH%" in content["deploy_script"][0]
     assert "UPLOAD_ON_BRANCH=foo-branch" in content["deploy_script"][-2]
 
@@ -553,7 +554,7 @@ def test_secrets(py_recipe, jinja_env):
     ):
         if config_yaml.endswith(".yaml"):
             with open(config_yaml) as fo:
-                config = yaml.safe_load(fo)
+                config = yaml.load(fo)
                 if "jobs" in config:
                     assert any(
                         any(
@@ -572,7 +573,7 @@ def test_secrets(py_recipe, jinja_env):
     )
 
     with open(os.path.join(py_recipe.recipe, ".drone.yml")) as fo:
-        config = list(yaml.safe_load_all(fo))[-1]
+        config = list(yaml.load_all(fo))[-1]
         assert any(
             step.get("environment", {})
             .get("BINSTAR_TOKEN", {})
@@ -596,7 +597,7 @@ def test_migrator_recipe(recipe_migration_cfep9, jinja_env):
             "linux_64_python2.7.yaml",
         )
     ) as fo:
-        variant = yaml.safe_load(fo)
+        variant = yaml.load(fo)
         assert variant["zlib"] == ["1000"]
 
 
@@ -629,7 +630,7 @@ def test_migrator_cfp_override(recipe_migration_cfep9, jinja_env):
             "linux_64_python2.7.yaml",
         )
     ) as fo:
-        variant = yaml.safe_load(fo)
+        variant = yaml.load(fo)
         assert variant["zlib"] == ["1001"]
 
 
@@ -693,7 +694,7 @@ def test_migrator_downgrade_recipe(
             "linux_64_python2.7.yaml",
         )
     ) as fo:
-        variant = yaml.safe_load(fo)
+        variant = yaml.load(fo)
         assert variant["zlib"] == ["1000"]
 
 
@@ -788,7 +789,7 @@ def test_webservices_action_exists(py_recipe, jinja_env):
     with open(
         os.path.join(py_recipe.recipe, ".github/workflows/webservices.yml")
     ) as f:
-        action_config = yaml.safe_load(f)
+        action_config = yaml.load(f)
     assert "jobs" in action_config
     assert "webservices" in action_config["jobs"]
 
@@ -805,7 +806,7 @@ def test_automerge_action_exists(py_recipe, jinja_env):
     with open(
         os.path.join(py_recipe.recipe, ".github/workflows/automerge.yml")
     ) as f:
-        action_config = yaml.safe_load(f)
+        action_config = yaml.load(f)
     assert "jobs" in action_config
     assert "automerge-action" in action_config["jobs"]
 

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -686,16 +686,17 @@ def test_migrator_downgrade_recipe(
         )
         == 2
     )
+    migration_dir = Path(
+        recipe_migration_cfep9_downgrade.recipe,
+        ".ci_support",
+        "migrations",
+    )
 
-    with open(
-        os.path.join(
-            recipe_migration_cfep9_downgrade.recipe,
-            ".ci_support",
-            "linux_64_python2.7.yaml",
-        )
-    ) as fo:
-        variant = yaml.load(fo)
-        assert variant["zlib"] == ["1000"]
+    for filename in os.listdir(migration_dir):
+        file_path = Path(migration_dir, filename)
+        with open(file_path) as fo:
+            variant = yaml.load(fo)
+            assert variant["zlib"] == ["1000"] if filename == "linux_64_python2.7.yaml" else ["999"]
 
 
 def test_migrator_compiler_version_recipe(


### PR DESCRIPTION
Modernize project dependencies
- [x] Use pathlib library **(Alba)**
- [x] Unify usage of ruamel (remove yaml to ensure consistency)
- [ ] Update relevant outdated dependencies


Refactor areas [in need](https://www.google.com/url?q=https://github.com/conda-forge/conda-smithy/blob/main/conda_smithy/configure_feedstock.py%23L701&sa=D&source=docs&ust=1715075663548960&usg=AOvVaw1f9qFmm9tfzTVhhhNqVq-i)
- [ ] Deprecate setup.py in favour of pyproject.toml and environment.yml
- [x] Remove unused code (imports, function parameters)
- [ ] Improve documentation

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
